### PR TITLE
WantedBy = default.target

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,7 +76,7 @@ in {
 			};
 
 			Install = {
-				WantedBy = ["multi-user.target"];
+				WantedBy = ["default.target"];
 			};
 		};
 


### PR DESCRIPTION
The `multi-user.target` doesn't exist in user-level systemd services (try `systemctl --user -t target`), so this service will never be activated. Instead this should be `WantedBy = default.target`, I think.